### PR TITLE
[25기 윤수연] Add: 장바구니 레이아웃 구현 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12237,15 +12237,15 @@
       }
     },
     "react-datepicker": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.2.1.tgz",
-      "integrity": "sha512-0gcvHMnX8rS1fV90PjjsB7MQdsWNU77JeVHf6bbwK9HnFxgwjVflTx40ebKmHV+leqe+f+FgUP9Nvqbe5RGyfA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.3.0.tgz",
+      "integrity": "sha512-cg+gp4YnPcZc6iZ0+v7VuRgcFG22KL7izHYrCxXeSLOn5VGkyxTfcu5qA/cGIsngurCt/u0NtgVTlHB1Fwap1g==",
       "requires": {
         "@popperjs/core": "^2.9.2",
         "classnames": "^2.2.6",
-        "date-fns": "^2.0.1",
+        "date-fns": "^2.24.0",
         "prop-types": "^15.7.2",
-        "react-onclickoutside": "^6.10.0",
+        "react-onclickoutside": "^6.12.0",
         "react-popper": "^2.2.5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
     "react": "^17.0.2",
-    "react-datepicker": "^4.2.1",
+    "react-datepicker": "^4.3.0",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",
     "react-router-dom": "^5.3.0",

--- a/public/data/FeeData.json
+++ b/public/data/FeeData.json
@@ -1,0 +1,24 @@
+{
+  "flights": [
+    {
+      "airline": "대한항공",
+      "code": "RS901",
+      "logoImage": "https://cdn.xxl.thumbs.canstockphoto.co.kr/%EB%B9%84%ED%96%89%EA%B8%B0-%EB%A1%9C%EA%B3%A0-%EB%94%94%EC%9E%90%EC%9D%B8-%EB%B3%B8%EB%9C%A8%EB%8A%94-%EA%B3%B5%EA%B5%AC-%EB%B2%A1%ED%84%B0-%ED%81%B4%EB%A6%BD%EC%95%84%ED%8A%B8_csp80172612.jpg",
+      "departureTime": "06:10",
+      "arriveTime": "7:10",
+      "seat": "일반석",
+      "extraSeat": "5석",
+      "price": 50000
+    },
+    {
+      "airline": "재롱에어",
+      "code": "JJ1204",
+      "logoImage": "https://t1.daumcdn.net/liveboard/Lovedoongdoong/ba449cf0fca541a4838afc41854aaacd.jpg",
+      "departureTime": "15:40",
+      "arriveTime": "16:50",
+      "seat": "비즈니스석",
+      "extraSeat": "3석",
+      "price": 290000
+    }
+  ]
+}

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -8,6 +8,7 @@ import ProductList from './components/ProductList/ProductList';
 import MainCityList from './pages/maincitylist/MainCityList';
 import Login from './pages/Login/Login';
 import Flightmainpage from './pages/flightmainpage/Flightmainpage';
+import Cart from './components/Cart/Cart';
 
 class Routes extends React.Component {
   render() {
@@ -21,6 +22,7 @@ class Routes extends React.Component {
           <Route exact path="/maincitylist" component={MainCityList} />
           <Route exact path={['/login', '/signup']} component={Login} />
           <Route exact path="/air" component={Flightmainpage} />
+          <Route exact path="/cart" component={Cart} />
         </Switch>
         <Footer />
       </Router>

--- a/src/components/Cart/Cart.js
+++ b/src/components/Cart/Cart.js
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import DetailedFee from './components/DetailedFee';
+import OneWayFlight from './components/OneWayFlight';
+
+const CartContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const ScheduleSelected = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+`;
+
+function Cart() {
+  const [flightInfo, setFlightInfo] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/FeeData.json')
+      .then(res => res.json())
+      .then(data => {
+        setFlightInfo(data.flights);
+      });
+  }, []);
+
+  if (!flightInfo || !flightInfo[0] || !flightInfo[1]) return null;
+  return (
+    <CartContainer>
+      <ScheduleSelected>
+        <OneWayFlight
+          ticket={flightInfo[0]}
+          title="가는편"
+          direction="김포 - 제주"
+        />
+        <OneWayFlight
+          ticket={flightInfo[1]}
+          title="오는편"
+          direction="제주 - 김포"
+        />
+      </ScheduleSelected>
+      <DetailedFee total={flightInfo[0].price + flightInfo[1].price} />
+    </CartContainer>
+  );
+}
+
+export default Cart;

--- a/src/components/Cart/components/DetailedFee.js
+++ b/src/components/Cart/components/DetailedFee.js
@@ -1,0 +1,172 @@
+import React from 'react';
+// import { Link } from 'react-router-dom';
+import styled from 'styled-components/macro';
+
+const Fee = styled.div`
+  margin-top: 16px;
+  padding: 24px;
+  background-color: #fff;
+  border-radius: 2px;
+  width: 80%;
+  margin: 0 auto;
+`;
+
+const Title = styled.h3`
+  margin-bottom: 16px;
+  font-size: 16px;
+  font-weight: 600;
+  color: black;
+`;
+
+const FeeTable = styled.table`
+  border-top: 1px solid #e9ecef;
+  width: 100%;
+  table-layout: fixed;
+`;
+
+const TableHead = styled.thead``;
+
+const TableRow = styled.tr``;
+
+const Item = styled.th`
+  padding: 8px 8px 8px 0;
+  border-bottom: 1px solid #e9ecef;
+  vertical-align: middle;
+  text-align: center;
+  font-size: 12px;
+`;
+
+const TableHeading = styled.th`
+  padding: 8px;
+  border-bottom: 1px solid #e9ecef;
+  vertical-align: middle;
+  text-align: center;
+  font-size: 12px;
+`;
+
+const LastTableHeading = styled.th`
+  padding: 8px 0 8px 8px;
+  border-bottom: 1px solid #e9ecef;
+  vertical-align: middle;
+  text-align: center;
+  font-size: 12px;
+`;
+
+const TableBody = styled.tbody`
+  border-bottom: 1px solid #e9ecef;
+`;
+
+const ItemDetail = styled.td`
+  padding: 16px 8px 16px 0;
+  font-size: 13px;
+  text-align: center;
+`;
+
+const TableDetail = styled.td`
+  padding: 16px 8px 16px 8px;
+  font-size: 13px;
+  text-align: center;
+`;
+
+const LastDetail = styled.td`
+  padding: 16px 0 16px 8px;
+  font-size: 13px;
+  text-align: center;
+`;
+
+const TableFoot = styled.tfoot`
+  vertical-align: baseline;
+  line-height: 24px;
+`;
+
+const Total = styled.td`
+  font-size: 16px;
+  padding-top: 16px;
+  line-height: 24px;
+  font-weight: 700;
+`;
+
+const Cost = styled.td`
+  font-size: 16px;
+  padding: 16px 24px 0 0;
+  text-align: right;
+  font-weight: 700;
+`;
+
+const FareTotal = styled.em`
+  font-size: 24px;
+  line-height: 24px;
+  margin-bottom: 2px;
+  text-align: right;
+`;
+const Unit = styled.span`
+  font-size: 20px;
+  font-weight: 600;
+`;
+
+const Btn = styled.div`
+  text-align: right;
+  padding-top: 16px;
+  font-weight: 700;
+`;
+
+const BookingBtn = styled.button`
+  line-height: 24px;
+  font-weight: 700;
+  padding: 0 10px;
+  background-color: #51abf3;
+  color: white;
+  height: 48px;
+  border-radius: 2px;
+  font-size: 16px;
+  border: none;
+  min-width: 120px;
+`;
+
+function DetailedFee({ total }) {
+  return (
+    <Fee>
+      <Title> 상세요금 </Title>
+      <FeeTable>
+        <TableHead>
+          <TableRow>
+            <Item>항목</Item>
+            <TableHeading>항공요금</TableHeading>
+            <TableHeading>유류할증료</TableHeading>
+            <TableHeading>제세공과금</TableHeading>
+            <TableHeading>발권수수료</TableHeading>
+            <TableHeading>인원</TableHeading>
+            <TableHeading>마이리얼트립할인</TableHeading>
+            <LastTableHeading>총요금</LastTableHeading>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <ItemDetail>성인</ItemDetail>
+            <TableDetail>{(total - 15600).toLocaleString()}</TableDetail>
+            <TableDetail>7,700원</TableDetail>
+            <TableDetail>8,000원</TableDetail>
+            <TableDetail>0원</TableDetail>
+            <TableDetail>1명</TableDetail>
+            <TableDetail>100원</TableDetail>
+            <LastDetail>{total.toLocaleString()}원</LastDetail>
+          </TableRow>
+        </TableBody>
+        <TableFoot>
+          <TableRow>
+            <Total colSpan="5">총 예상요금</Total>
+            <Cost colSpan="2">
+              <FareTotal>{total.toLocaleString()}</FareTotal>
+              <Unit>원</Unit>
+            </Cost>
+            <Btn>
+              <BookingBtn>예약하기</BookingBtn>
+            </Btn>
+          </TableRow>
+        </TableFoot>
+      </FeeTable>
+    </Fee>
+  );
+}
+
+export default DetailedFee;

--- a/src/components/Cart/components/OneWayFlight.js
+++ b/src/components/Cart/components/OneWayFlight.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import styled from 'styled-components';
+
+function OneWayFlight({ ticket, title, direction }) {
+  const { airline, code, logoImage, departureTime, arriveTime, seat, price } =
+    ticket;
+
+  return (
+    <Data>
+      <Direction>{title}</Direction>
+      <DirectionArea>{direction}</DirectionArea>
+      <DirectionDate>10월22일(금)</DirectionDate>
+      <Photo>
+        <Img alt={airline} src={logoImage} />
+      </Photo>
+      <Air>
+        <p>{airline}</p>
+        <p>{code}</p>
+      </Air>
+      <Time>
+        <H>{arriveTime}</H>
+        <Gmp>GMP</Gmp>
+      </Time>
+      <Div>
+        <Arrow alt="화살표" src="/images/arrow.png" />
+        <Hour> 1시간 10분 </Hour>
+      </Div>
+      <Arrive>
+        <ArriveTime>{departureTime}</ArriveTime>
+        <Destination>CJU</Destination>
+      </Arrive>
+      <Seat>{seat}</Seat>
+      <Price>{price.toLocaleString()}원</Price>
+    </Data>
+  );
+}
+
+export default OneWayFlight;
+
+const Data = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 80%;
+  height: 70px;
+  margin: 10px 0 24px 0;
+  padding: 16px 24px;
+  background-color: white;
+  border-radius: 3px;
+  border: 0.5px solid rgba(0, 0, 0, 0.1);
+`;
+
+const Direction = styled.span`
+  padding: 5px 5px;
+  background-color: ${props => props.theme.subColor};
+  border-radius: 2px;
+  color: white;
+  font-size: 13px;
+  font-weight: 600;
+`;
+
+const DirectionArea = styled.span`
+  padding-top: 3px;
+  font-size: 16px;
+  font-weight: 500;
+`;
+
+const DirectionDate = styled.span`
+  padding-top: 3px;
+  font-size: 14px;
+`;
+
+const Photo = styled.div``;
+
+const Img = styled.img`
+  width: 40px;
+`;
+
+const Air = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 13px;
+`;
+
+const Time = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const H = styled.p`
+  font-weight: bold;
+  font-size: 16px;
+  color: #343a40;
+`;
+
+const Gmp = styled.p`
+  font-size: 13px;
+  color: #666d75;
+  text-align: center;
+`;
+
+const Div = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 7px;
+`;
+
+const Arrow = styled.img`
+  width: 76px;
+  height: 8px;
+`;
+
+const Hour = styled.p`
+  color: #848c94;
+  font-size: 13px;
+  text-align: center;
+`;
+
+const Arrive = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+`;
+
+const ArriveTime = styled.p`
+  font-weight: bold;
+  font-size: 16px;
+  color: #343a40;
+`;
+
+const Destination = styled.p`
+  font-size: 13px;
+  color: #666d75;
+  text-align: center;
+`;
+
+const Seat = styled.div`
+  font-size: 13px;
+  color: #343a40;
+`;
+
+const Price = styled.strong`
+  font-size: 20px;
+  font-weight: bold;
+`;

--- a/src/config.js
+++ b/src/config.js
@@ -1,12 +1,10 @@
-const BASE_URL = 'http://3.34.96.53:8000';
+const IP = 'http://3.34.96.53:8000';
 
-export const API = {
-  BASE_URL: `${BASE_URL}`,
-  PRODUCT_DETAIL: `${BASE_URL}/products`, // search_result
-  SEARCH: `${BASE_URL}/products?search=`,
-  SIGNUP: `${BASE_URL}/users/signup`,
-  SIGNIN: `${BASE_URL}/users/signin`,
-  CART: `${BASE_URL}/carts`, //  post & get
-  REVIEW: `${BASE_URL}/reviews`, // 상품리뷰 하나보기
-  TOTAL_REVIEW: `${BASE_URL}/products/reviews`, // 상품리뷰 전체보는거
+const API = {
+  login: `${IP}/users/login`, //로그인페이지
+  products: `${IP}/menus/subproduct`, //상품리스트 (별점있는상품리스트)
+  reservations: `${IP}/reservations`, //예약페이지(도착&출발,날짜,승객수,항공사,좌석)
+  cart: `${IP}/cart`, //장바구니
 };
+
+export default API;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 예약 페이지에서 선택된 스케쥴을 전달받아 장바구니에서 상세요금과 총 예상요금을 출력합니다.
- 상세요금과 총 예상요금은 예약페이지에서 전달받습니다.
- 사용자가 예약하기 버튼을 누르면 결제페이지로 이동과 동시에 상품내용을 전달합니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 상세요금 데이터 처리
- 예약페이지에서 링크로 데이터를 전달받아서 페이지에 출력

2. 버튼 클릭 기능
- 사용자가 예약버튼 클릭시 결제페이지로 이동

3. 총 금액 계산
- 전달받은 데이터에서 비행기 왕복으로 총 예상금액 계산해서 출력

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 상세요금 테이블을 만들면서 능숙하지 않았던 tr, th, td 순서를 익히고 전체적인 개념을 다시 복습했습니다.
- 데이터를 전달하고 받을 때 어떤 메소드를 활용해야 할지 완벽하게 개념을 이해하지 못 했다. 글로 전체적인 내용을 정리해서 블로그에 올려야겠다.

<br />

## :: 기타 질문 및 특이 사항
- 예약페이지 항공 컴포넌트에서 레이아웃 재사용